### PR TITLE
Set up HairGuard foundation navigation scaffold

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,112 @@
 import 'package:flutter/material.dart';
 
+import 'navigation/app_navigation.dart';
+import 'screens/home_screen.dart';
+import 'screens/profile_screen.dart';
+import 'screens/results_screen.dart';
+import 'screens/scan_screen.dart';
+import 'services/app_dependencies.dart';
+import 'services/offline_data_store.dart';
+import 'services/permission_service.dart';
+import 'services/processing_service.dart';
+
 void main() {
-  runApp(const MyApp());
+  runApp(const HairGuardApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class HairGuardApp extends StatefulWidget {
+  const HairGuardApp({super.key});
 
-  // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
+  State<HairGuardApp> createState() => _HairGuardAppState();
+}
+
+class _HairGuardAppState extends State<HairGuardApp> {
+  late final OfflineDataStore _offlineDataStore;
+  late final PermissionService _permissionService;
+  late final ProcessingService _processingService;
+  int _currentIndex = AppTab.home.index;
+
+  @override
+  void initState() {
+    super.initState();
+    _offlineDataStore = OfflineDataStore()..initialize();
+    _permissionService = PermissionService();
+    _processingService = ProcessingService();
   }
-}
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
+  void _onTabSelected(int index) {
+    if (index == _currentIndex) {
+      return;
+    }
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _currentIndex = index;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+    return AppDependencies(
+      offlineDataStore: _offlineDataStore,
+      permissionService: _permissionService,
+      processingService: _processingService,
+      child: MaterialApp(
+        title: 'HairGuard',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+        ),
+        home: AppShell(
+          currentIndex: _currentIndex,
+          onTabSelected: _onTabSelected,
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}
+
+class AppShell extends StatelessWidget {
+  const AppShell({
+    super.key,
+    required this.currentIndex,
+    required this.onTabSelected,
+  });
+
+  final int currentIndex;
+  final ValueChanged<int> onTabSelected;
+
+  Widget _buildBody() {
+    switch (AppTab.values[currentIndex]) {
+      case AppTab.home:
+        return const HomeScreen();
+      case AppTab.scan:
+        return const ScanScreen();
+      case AppTab.results:
+        return const ResultsScreen();
+      case AppTab.profile:
+        return const ProfileScreen();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget body = _buildBody();
+    return DefaultTabNavigator(
+      goTo: (AppTab tab) => onTabSelected(tab.index),
+      child: Scaffold(
+        body: body,
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: currentIndex,
+          onTap: onTabSelected,
+          items: AppTab.values
+              .map(
+                (tab) => BottomNavigationBarItem(
+                  icon: Icon(tab.icon),
+                  label: tab.label,
+                ),
+              )
+              .toList(),
+        ),
+      ),
     );
   }
 }

--- a/lib/navigation/app_navigation.dart
+++ b/lib/navigation/app_navigation.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+enum AppTab { home, scan, results, profile }
+
+extension AppTabMetadata on AppTab {
+  String get label {
+    switch (this) {
+      case AppTab.home:
+        return 'Home';
+      case AppTab.scan:
+        return 'Scan';
+      case AppTab.results:
+        return 'Results';
+      case AppTab.profile:
+        return 'Profile';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case AppTab.home:
+        return Icons.home_outlined;
+      case AppTab.scan:
+        return Icons.camera_alt_outlined;
+      case AppTab.results:
+        return Icons.analytics_outlined;
+      case AppTab.profile:
+        return Icons.person_outline;
+    }
+  }
+}
+
+extension AppTabParsing on AppTab {
+  static AppTab fromIndex(int index) {
+    if (index < 0 || index >= AppTab.values.length) {
+      return AppTab.home;
+    }
+    return AppTab.values[index];
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../navigation/app_navigation.dart';
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+
+    return AnimatedBuilder(
+      animation: store,
+      builder: (BuildContext context, _) {
+        if (!store.isInitialized) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Welcome to HairGuard',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Good lighting, a steady hand, and framing each angle will help you get accurate insights.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton.icon(
+                  onPressed: () => DefaultTabNavigator.of(context)?.goTo(AppTab.scan),
+                  icon: const Icon(Icons.camera_alt_outlined),
+                  label: const Text('Start a new scan'),
+                ),
+                const SizedBox(height: 24),
+                if (store.sessions.isEmpty)
+                  const Expanded(
+                    child: Center(
+                      child: Text('No scans yet — capture your first session to unlock results.'),
+                    ),
+                  )
+                else
+                  Expanded(
+                    child: ListView.separated(
+                      itemCount: store.sessions.length,
+                      separatorBuilder: (_, __) => const Divider(),
+                      itemBuilder: (BuildContext context, int index) {
+                        final ScanSession session = store.sessions[index];
+                        return ListTile(
+                          leading: const Icon(Icons.history),
+                          title: Text(session.summary ?? 'Session ${session.id}'),
+                          subtitle: Text('Captured on ${session.createdAt.toLocal()}'),
+                        );
+                      },
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class DefaultTabNavigator extends InheritedWidget {
+  const DefaultTabNavigator({
+    super.key,
+    required super.child,
+    required this.goTo,
+  });
+
+  final void Function(AppTab tab) goTo;
+
+  static DefaultTabNavigator? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DefaultTabNavigator>();
+  }
+
+  @override
+  bool updateShouldNotify(DefaultTabNavigator oldWidget) => goTo != oldWidget.goTo;
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Profile & privacy',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Manage your local data. Everything stays on this device unless you choose to export it.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: store.isInitialized
+                  ? () async {
+                      await store.clearSessions();
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Local data cleared.')),
+                        );
+                      }
+                    }
+                  : null,
+              icon: const Icon(Icons.delete_outline),
+              label: const Text('Delete local sessions'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+import '../services/processing_service.dart';
+
+class ResultsScreen extends StatelessWidget {
+  const ResultsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+    final ProcessingService processingService =
+        AppDependencies.of(context).processingService;
+
+    return AnimatedBuilder(
+      animation: store,
+      builder: (BuildContext context, _) {
+        if (!store.isInitialized) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final ScanSession? latestSession =
+            store.sessions.isNotEmpty ? store.sessions.first : null;
+
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Results overview',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Stored locally: ${store.sessions.length} session(s).',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  latestSession == null
+                      ? 'No processed sessions yet. Complete a scan to see your results summary here.'
+                      : latestSession.summary ?? 'Latest session ready to review.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16),
+                if (latestSession != null)
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text('Model version: ${processingService.modelVersion}'),
+                          const SizedBox(height: 8),
+                          Text('Captured: ${latestSession.createdAt.toLocal()}'),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/scan_screen.dart
+++ b/lib/screens/scan_screen.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+import '../services/permission_service.dart';
+import '../services/processing_service.dart';
+
+class ScanScreen extends StatefulWidget {
+  const ScanScreen({super.key});
+
+  @override
+  State<ScanScreen> createState() => _ScanScreenState();
+}
+
+class _ScanScreenState extends State<ScanScreen> {
+  bool _isProcessing = false;
+  String? _statusMessage;
+  List<String>? _lastConditions;
+
+  Future<void> _handleSimulatedCapture() async {
+    final PermissionService permissionService =
+        AppDependencies.of(context).permissionService;
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+    final ProcessingService processingService =
+        AppDependencies.of(context).processingService;
+
+    setState(() {
+      _isProcessing = true;
+      _statusMessage = 'Checking camera permission...';
+    });
+
+    final PermissionStatus status = await permissionService.ensureCameraPermission();
+    if (!mounted) return;
+
+    if (status != PermissionStatus.granted) {
+      setState(() {
+        _isProcessing = false;
+        _statusMessage = 'Camera permission required to continue.';
+      });
+      return;
+    }
+
+    setState(() {
+      _statusMessage = 'Processing locally...';
+    });
+
+    final ProcessingResult result =
+        await processingService.processCaptureSet(const <String>['top', 'side', 'back']);
+
+    if (!mounted) return;
+
+    await store.saveSession(
+      ScanSession(
+        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        createdAt: DateTime.now(),
+        summary: result.summary,
+      ),
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessing = false;
+      _lastConditions = result.conditions;
+      _statusMessage = 'Session stored locally (${result.modelVersion}).';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Ready for a new scan',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'This prototype simulates the capture flow and stores the output locally to honor the offline-first approach.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: _isProcessing ? null : _handleSimulatedCapture,
+              icon: const Icon(Icons.qr_code_scanner),
+              label: Text(_isProcessing ? 'Processing…' : 'Simulate capture set'),
+            ),
+            const SizedBox(height: 16),
+            if (_statusMessage != null)
+              Text(
+                _statusMessage!,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: Colors.teal.shade700),
+              ),
+            if (_lastConditions != null && _lastConditions!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: _lastConditions!
+                      .map(
+                        (String condition) => Text(
+                          '• $condition',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      )
+                      .toList(),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/app_dependencies.dart
+++ b/lib/services/app_dependencies.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+
+import 'offline_data_store.dart';
+import 'permission_service.dart';
+import 'processing_service.dart';
+
+class AppDependencies extends InheritedWidget {
+  const AppDependencies({
+    super.key,
+    required super.child,
+    required this.offlineDataStore,
+    required this.permissionService,
+    required this.processingService,
+  });
+
+  final OfflineDataStore offlineDataStore;
+  final PermissionService permissionService;
+  final ProcessingService processingService;
+
+  static AppDependencies of(BuildContext context) {
+    final AppDependencies? dependencies =
+        context.dependOnInheritedWidgetOfExactType<AppDependencies>();
+    assert(
+      dependencies != null,
+      'AppDependencies.of() called with a context that does not contain AppDependencies.',
+    );
+    return dependencies!;
+  }
+
+  @override
+  bool updateShouldNotify(AppDependencies oldWidget) {
+    return offlineDataStore != oldWidget.offlineDataStore ||
+        permissionService != oldWidget.permissionService ||
+        processingService != oldWidget.processingService;
+  }
+}

--- a/lib/services/offline_data_store.dart
+++ b/lib/services/offline_data_store.dart
@@ -1,0 +1,46 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+class ScanSession {
+  ScanSession({
+    required this.id,
+    required this.createdAt,
+    this.summary,
+  });
+
+  final String id;
+  final DateTime createdAt;
+  final String? summary;
+}
+
+class OfflineDataStore extends ChangeNotifier {
+  bool _initialized = false;
+  final List<ScanSession> _sessions = <ScanSession>[];
+
+  bool get isInitialized => _initialized;
+
+  UnmodifiableListView<ScanSession> get sessions =>
+      UnmodifiableListView<ScanSession>(_sessions);
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    _initialized = true;
+    notifyListeners();
+  }
+
+  Future<void> saveSession(ScanSession session) async {
+    await initialize();
+    _sessions.insert(0, session);
+    notifyListeners();
+  }
+
+  Future<void> clearSessions() async {
+    await initialize();
+    _sessions.clear();
+    notifyListeners();
+  }
+}

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -1,0 +1,19 @@
+enum PermissionStatus { granted, denied, restricted }
+
+class PermissionService {
+  PermissionStatus _cameraStatus = PermissionStatus.denied;
+
+  PermissionStatus get cameraStatus => _cameraStatus;
+
+  Future<PermissionStatus> ensureCameraPermission() async {
+    if (_cameraStatus == PermissionStatus.granted) {
+      return _cameraStatus;
+    }
+
+    // Placeholder stub: in a real implementation this would request the
+    // platform permission. We simulate a granted response after a short delay.
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    _cameraStatus = PermissionStatus.granted;
+    return _cameraStatus;
+  }
+}

--- a/lib/services/processing_service.dart
+++ b/lib/services/processing_service.dart
@@ -1,0 +1,29 @@
+class ProcessingResult {
+  ProcessingResult({
+    required this.summary,
+    required this.conditions,
+    required this.modelVersion,
+  });
+
+  final String summary;
+  final List<String> conditions;
+  final String modelVersion;
+}
+
+class ProcessingService {
+  String get modelVersion => 'v0.1-local';
+
+  Future<ProcessingResult> processCaptureSet(List<String> imagePaths) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+
+    return ProcessingResult(
+      summary: imagePaths.isEmpty
+          ? 'No captures yet — start a new scan to see insights.'
+          : 'Preliminary results ready to review.',
+      conditions: imagePaths.isEmpty
+          ? const <String>[]
+          : const <String>['Dandruff — Moderate', 'Irritation — Mild'],
+      modelVersion: modelVersion,
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,19 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:skalp_guard/main.dart';
+import 'package:skalp_guard/navigation/app_navigation.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Bottom navigation renders four HairGuard tabs', (WidgetTester tester) async {
+    await tester.pumpWidget(const HairGuardApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    final BottomNavigationBar bottomNav =
+        tester.widget(find.byType(BottomNavigationBar));
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(bottomNav.items, hasLength(AppTab.values.length));
+    for (final AppTab tab in AppTab.values) {
+      expect(find.text(tab.label), findsWidgets);
+    }
   });
 }


### PR DESCRIPTION
## Summary
- replace the counter sample with a HairGuard app shell that exposes Home, Scan, Results, and Profile tabs via bottom navigation
- add shared dependency wiring plus offline data store, permission, and processing service stubs to support the offline-first flow
- scaffold initial tab screens that exercise the services and refresh the widget test to assert the tab structure

## Testing
- `flutter test` *(fails: flutter SDK is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de577bfd348326958e04a09c58e236