### PR TITLE
Add onboarding and account setup flows with scan preparation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,159 @@
 import 'package:flutter/material.dart';
 
+import 'navigation/app_navigation.dart';
+import 'screens/home_screen.dart';
+import 'screens/onboarding_screen.dart';
+import 'screens/profile_screen.dart';
+import 'screens/results_screen.dart';
+import 'screens/scan_screen.dart';
+import 'screens/sign_in_screen.dart';
+import 'services/app_dependencies.dart';
+import 'services/account_service.dart';
+import 'services/analytics_service.dart';
+import 'services/legal_content_service.dart';
+import 'services/offline_data_store.dart';
+import 'services/permission_service.dart';
+import 'services/processing_service.dart';
+
 void main() {
-  runApp(const MyApp());
+  runApp(const HairGuardApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class HairGuardApp extends StatefulWidget {
+  const HairGuardApp({super.key});
 
-  // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
+  State<HairGuardApp> createState() => _HairGuardAppState();
+}
+
+class _HairGuardAppState extends State<HairGuardApp> {
+  late final OfflineDataStore _offlineDataStore;
+  late final PermissionService _permissionService;
+  late final ProcessingService _processingService;
+  late final AccountService _accountService;
+  late final AnalyticsService _analyticsService;
+  late final LegalContentService _legalContentService;
+  int _currentIndex = AppTab.home.index;
+
+  @override
+  void initState() {
+    super.initState();
+    _offlineDataStore = OfflineDataStore()..initialize();
+    _permissionService = PermissionService();
+    _processingService = ProcessingService();
+    _accountService = AccountService();
+    _analyticsService = AnalyticsService();
+    _legalContentService = LegalContentService();
   }
-}
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
+  void _onTabSelected(int index) {
+    if (index == _currentIndex) {
+      return;
+    }
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      _currentIndex = index;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+    return AppDependencies(
+      offlineDataStore: _offlineDataStore,
+      permissionService: _permissionService,
+      processingService: _processingService,
+      accountService: _accountService,
+      analyticsService: _analyticsService,
+      legalContentService: _legalContentService,
+      child: AnimatedBuilder(
+        animation: _offlineDataStore,
+        builder: (BuildContext context, _) {
+          return MaterialApp(
+            title: 'HairGuard',
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
             ),
-          ],
+            home: _buildRoot(context),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildRoot(BuildContext context) {
+    if (!_offlineDataStore.isInitialized) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (!_offlineDataStore.hasCompletedOnboarding) {
+      return OnboardingScreen(
+        onContinue: () => _offlineDataStore.setOnboardingComplete(),
+      );
+    }
+
+    if (_offlineDataStore.shouldPromptForAccount) {
+      return SignInScreen(
+        onAccountLinked: (String accountId) async {
+          await _offlineDataStore.linkAccount(accountId);
+        },
+        onSkip: () async {
+          _analyticsService.recordEvent('account_skip');
+          await _offlineDataStore.skipAccount();
+        },
+      );
+    }
+
+    return AppShell(
+      currentIndex: _currentIndex,
+      onTabSelected: _onTabSelected,
+    );
+  }
+}
+
+class AppShell extends StatelessWidget {
+  const AppShell({
+    super.key,
+    required this.currentIndex,
+    required this.onTabSelected,
+  });
+
+  final int currentIndex;
+  final ValueChanged<int> onTabSelected;
+
+  Widget _buildBody() {
+    switch (AppTab.values[currentIndex]) {
+      case AppTab.home:
+        return const HomeScreen();
+      case AppTab.scan:
+        return const ScanScreen();
+      case AppTab.results:
+        return const ResultsScreen();
+      case AppTab.profile:
+        return const ProfileScreen();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget body = _buildBody();
+    return DefaultTabNavigator(
+      goTo: (AppTab tab) => onTabSelected(tab.index),
+      child: Scaffold(
+        body: body,
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: currentIndex,
+          onTap: onTabSelected,
+          items: AppTab.values
+              .map(
+                (tab) => BottomNavigationBarItem(
+                  icon: Icon(tab.icon),
+                  label: tab.label,
+                ),
+              )
+              .toList(),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/lib/navigation/app_navigation.dart
+++ b/lib/navigation/app_navigation.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+enum AppTab { home, scan, results, profile }
+
+extension AppTabMetadata on AppTab {
+  String get label {
+    switch (this) {
+      case AppTab.home:
+        return 'Home';
+      case AppTab.scan:
+        return 'Scan';
+      case AppTab.results:
+        return 'Results';
+      case AppTab.profile:
+        return 'Profile';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case AppTab.home:
+        return Icons.home_outlined;
+      case AppTab.scan:
+        return Icons.camera_alt_outlined;
+      case AppTab.results:
+        return Icons.analytics_outlined;
+      case AppTab.profile:
+        return Icons.person_outline;
+    }
+  }
+}
+
+extension AppTabParsing on AppTab {
+  static AppTab fromIndex(int index) {
+    if (index < 0 || index >= AppTab.values.length) {
+      return AppTab.home;
+    }
+    return AppTab.values[index];
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+
+import '../navigation/app_navigation.dart';
+import '../services/app_dependencies.dart';
+import '../services/legal_content_service.dart';
+import '../services/offline_data_store.dart';
+import '../widgets/legal_document_sheet.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  static const List<String> _tips = <String>[
+    'Stand near a window or soft light to avoid harsh shadows.',
+    'Clean your camera lens for clearer images of your scalp.',
+    'Frame the guides so the top, side, and back views fill the screen.',
+    'Ask a friend for help capturing the back view if possible.',
+  ];
+
+  int _tipIndex = 0;
+
+  void _cycleTip() {
+    setState(() {
+      _tipIndex = (_tipIndex + 1) % _tips.length;
+    });
+  }
+
+  Future<void> _showPrivacySheet(BuildContext context) async {
+    final LegalContentService legalService =
+        AppDependencies.of(context).legalContentService;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext context) => LegalDocumentSheet(
+        title: 'Privacy Policy',
+        loader: () => legalService.fetchDocument(LegalDocumentType.privacy),
+      ),
+    );
+  }
+
+  Future<void> _showHowItWorksSheet(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (BuildContext context) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const <Widget>[
+              Text(
+                'How HairGuard works',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w600),
+              ),
+              SizedBox(height: 12),
+              _HowItWorksStep(
+                icon: Icons.filter_3,
+                text: 'Follow the guided prep checklist to get ready.',
+              ),
+              _HowItWorksStep(
+                icon: Icons.camera_alt_outlined,
+                text: 'Capture top, side, and back views with on-screen guidance.',
+              ),
+              _HowItWorksStep(
+                icon: Icons.insights_outlined,
+                text: 'Processing runs on your phone to surface friendly insights.',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+
+    return AnimatedBuilder(
+      animation: store,
+      builder: (BuildContext context, _) {
+        if (!store.isInitialized) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final ThemeData theme = Theme.of(context);
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Card(
+                  color: theme.colorScheme.primaryContainer,
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          'Welcome to HairGuard',
+                          style: theme.textTheme.titleLarge,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          'Keep an eye on your scalp with guided captures. Everything stays on this device by default.',
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Icon(Icons.tips_and_updates_outlined, color: theme.colorScheme.primary),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              Text('Capture tip', style: theme.textTheme.titleMedium),
+                              const SizedBox(height: 4),
+                              Text(_tips[_tipIndex], style: theme.textTheme.bodyMedium),
+                            ],
+                          ),
+                        ),
+                        IconButton(
+                          onPressed: _cycleTip,
+                          icon: const Icon(Icons.refresh),
+                          tooltip: 'Show another tip',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 12,
+                  children: <Widget>[
+                    TextButton(
+                      onPressed: () => _showHowItWorksSheet(context),
+                      child: const Text('How it works'),
+                    ),
+                    TextButton(
+                      onPressed: () => _showPrivacySheet(context),
+                      child: const Text('Privacy'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: () => DefaultTabNavigator.of(context)?.goTo(AppTab.scan),
+                    icon: const Icon(Icons.camera_alt_outlined),
+                    label: const Text('Start a new scan'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: store.sessions.isEmpty
+                      ? const _EmptyState()
+                      : ListView.separated(
+                          itemCount: store.sessions.length,
+                          separatorBuilder: (_, __) => const Divider(),
+                          itemBuilder: (BuildContext context, int index) {
+                            final ScanSession session = store.sessions[index];
+                            return ListTile(
+                              leading: const Icon(Icons.history),
+                              title: Text(session.summary ?? 'Session ${session.id}'),
+                              subtitle: Text('Captured on ${session.createdAt.toLocal()}'),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(Icons.camera_enhance_outlined, size: 48, color: theme.colorScheme.primary),
+          const SizedBox(height: 12),
+          const Text('No scans yet — start your first scan to build your history.'),
+        ],
+      ),
+    );
+  }
+}
+
+class _HowItWorksStep extends StatelessWidget {
+  const _HowItWorksStep({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, color: theme.colorScheme.primary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class DefaultTabNavigator extends InheritedWidget {
+  const DefaultTabNavigator({
+    super.key,
+    required super.child,
+    required this.goTo,
+  });
+
+  final void Function(AppTab tab) goTo;
+
+  static DefaultTabNavigator? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<DefaultTabNavigator>();
+  }
+
+  @override
+  bool updateShouldNotify(DefaultTabNavigator oldWidget) => goTo != oldWidget.goTo;
+}

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/legal_content_service.dart';
+import '../widgets/legal_document_sheet.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key, required this.onContinue});
+
+  final Future<void> Function() onContinue;
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final PageController _pageController = PageController();
+  final List<_OnboardingSlide> _slides = const <_OnboardingSlide>[
+    _OnboardingSlide(
+      icon: Icons.spa_outlined,
+      title: 'Understand your scalp',
+      description:
+          'HairGuard provides guided captures to spot changes in your scalp over time.',
+    ),
+    _OnboardingSlide(
+      icon: Icons.shield_moon_outlined,
+      title: 'Privacy-first design',
+      description:
+          'All analysis runs on your device. Nothing uploads unless you decide to share it.',
+    ),
+    _OnboardingSlide(
+      icon: Icons.health_and_safety_outlined,
+      title: 'Not a diagnosis',
+      description:
+          'HairGuard offers screening guidance. If symptoms worsen, please see a healthcare professional.',
+    ),
+    _OnboardingSlide(
+      icon: Icons.lightbulb_outline,
+      title: 'Capture tips',
+      description:
+          'Use bright, even lighting, hold steady, and follow the guides for top, side, and back views.',
+    ),
+  ];
+
+  int _currentPage = 0;
+  bool _consentGiven = false;
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleContinue() async {
+    if (!_consentGiven || _isSubmitting) {
+      return;
+    }
+    setState(() {
+      _isSubmitting = true;
+    });
+    await widget.onContinue();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _isSubmitting = false;
+    });
+  }
+
+  Future<void> _openDocument(LegalDocumentType type, String title) async {
+    final LegalContentService legalContentService =
+        AppDependencies.of(context).legalContentService;
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext context) => LegalDocumentSheet(
+        title: title,
+        loader: () => legalContentService.fetchDocument(type),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('Welcome to HairGuard', style: theme.textTheme.headlineSmall),
+              const SizedBox(height: 16),
+              Expanded(
+                child: Column(
+                  children: <Widget>[
+                    Expanded(
+                      child: PageView.builder(
+                        controller: _pageController,
+                        itemCount: _slides.length,
+                        onPageChanged: (int page) {
+                          setState(() {
+                            _currentPage = page;
+                          });
+                        },
+                        itemBuilder: (BuildContext context, int index) {
+                          final _OnboardingSlide slide = _slides[index];
+                          return Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              Icon(slide.icon, size: 72, color: theme.colorScheme.primary),
+                              const SizedBox(height: 24),
+                              Text(
+                                slide.title,
+                                style: theme.textTheme.titleLarge,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                slide.description,
+                                style: theme.textTheme.bodyMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: List<Widget>.generate(_slides.length, (int index) {
+                        final bool isActive = _currentPage == index;
+                        return AnimatedContainer(
+                          duration: const Duration(milliseconds: 250),
+                          margin: const EdgeInsets.symmetric(horizontal: 4),
+                          height: 8,
+                          width: isActive ? 20 : 8,
+                          decoration: BoxDecoration(
+                            color: isActive
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.primary.withOpacity(0.3),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                        );
+                      }),
+                    ),
+                    const SizedBox(height: 16),
+                    Wrap(
+                      alignment: WrapAlignment.center,
+                      spacing: 12,
+                      children: <Widget>[
+                        TextButton(
+                          onPressed: () => _openDocument(LegalDocumentType.terms, 'Terms of Use'),
+                          child: const Text('Terms of Use'),
+                        ),
+                        TextButton(
+                          onPressed: () => _openDocument(LegalDocumentType.privacy, 'Privacy Policy'),
+                          child: const Text('Privacy Policy'),
+                        ),
+                      ],
+                    ),
+                    CheckboxListTile(
+                      value: _consentGiven,
+                      onChanged: (bool? value) {
+                        setState(() {
+                          _consentGiven = value ?? false;
+                        });
+                      },
+                      controlAffinity: ListTileControlAffinity.leading,
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text(
+                        'I understand that HairGuard runs on my device and offers guidance, not a diagnosis.',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _consentGiven && !_isSubmitting ? _handleContinue : null,
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Continue'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardingSlide {
+  const _OnboardingSlide({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+}
+

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Profile & privacy',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Manage your local data. Everything stays on this device unless you choose to export it.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: store.isInitialized
+                  ? () async {
+                      await store.clearSessions();
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Local data cleared.')),
+                        );
+                      }
+                    }
+                  : null,
+              icon: const Icon(Icons.delete_outline),
+              label: const Text('Delete local sessions'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+import '../services/processing_service.dart';
+
+class ResultsScreen extends StatelessWidget {
+  const ResultsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+    final ProcessingService processingService =
+        AppDependencies.of(context).processingService;
+
+    return AnimatedBuilder(
+      animation: store,
+      builder: (BuildContext context, _) {
+        if (!store.isInitialized) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final ScanSession? latestSession =
+            store.sessions.isNotEmpty ? store.sessions.first : null;
+
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Results overview',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Stored locally: ${store.sessions.length} session(s).',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  latestSession == null
+                      ? 'No processed sessions yet. Complete a scan to see your results summary here.'
+                      : latestSession.summary ?? 'Latest session ready to review.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16),
+                if (latestSession != null)
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text('Model version: ${processingService.modelVersion}'),
+                          const SizedBox(height: 8),
+                          Text('Captured: ${latestSession.createdAt.toLocal()}'),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/scan_screen.dart
+++ b/lib/screens/scan_screen.dart
@@ -1,0 +1,299 @@
+import 'package:flutter/material.dart';
+
+import '../services/app_dependencies.dart';
+import '../services/offline_data_store.dart';
+import '../services/permission_service.dart';
+import '../services/processing_service.dart';
+
+class ScanScreen extends StatefulWidget {
+  const ScanScreen({super.key});
+
+  @override
+  State<ScanScreen> createState() => _ScanScreenState();
+}
+
+class _ScanScreenState extends State<ScanScreen> {
+  static const List<String> _checklistItems = <String>[
+    'Find bright, even lighting (avoid harsh shadows).',
+    'Clean your camera lens for a clear view.',
+    'Remove hats, accessories, or hair toppers.',
+    'Have someone help with the back view if available.',
+  ];
+
+  late final List<bool> _checklistSelections =
+      List<bool>.filled(_checklistItems.length, false);
+  bool _isReadyForCapture = false;
+  bool _isProcessing = false;
+  String? _statusMessage;
+  List<String>? _lastConditions;
+
+  Future<void> _handleSimulatedCapture() async {
+    final PermissionService permissionService =
+        AppDependencies.of(context).permissionService;
+    final OfflineDataStore store = AppDependencies.of(context).offlineDataStore;
+    final ProcessingService processingService =
+        AppDependencies.of(context).processingService;
+
+    setState(() {
+      _isProcessing = true;
+      _statusMessage = 'Checking camera permission...';
+    });
+
+    final PermissionStatus status = await permissionService.ensureCameraPermission();
+    if (!mounted) return;
+
+    if (status != PermissionStatus.granted) {
+      setState(() {
+        _isProcessing = false;
+        _statusMessage = 'Camera permission required to continue.';
+      });
+      return;
+    }
+
+    setState(() {
+      _statusMessage = 'Processing locally...';
+    });
+
+    final ProcessingResult result =
+        await processingService.processCaptureSet(const <String>['top', 'side', 'back']);
+
+    if (!mounted) return;
+
+    await store.saveSession(
+      ScanSession(
+        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        createdAt: DateTime.now(),
+        summary: result.summary,
+      ),
+    );
+
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessing = false;
+      _lastConditions = result.conditions;
+      _statusMessage = 'Session stored locally (${result.modelVersion}).';
+    });
+  }
+
+  bool get _allChecklistComplete =>
+      _checklistSelections.every((bool value) => value);
+
+  void _toggleChecklistItem(int index, bool? value) {
+    setState(() {
+      _checklistSelections[index] = value ?? false;
+    });
+  }
+
+  void _beginCapture() {
+    setState(() {
+      _isReadyForCapture = true;
+      _statusMessage = null;
+      _lastConditions = null;
+    });
+  }
+
+  void _returnToPreparation() {
+    setState(() {
+      _isReadyForCapture = false;
+      _isProcessing = false;
+      _statusMessage = null;
+      _lastConditions = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 250),
+          child: _isReadyForCapture
+              ? _CaptureSimulation(
+                  key: const ValueKey<String>('capture'),
+                  isProcessing: _isProcessing,
+                  statusMessage: _statusMessage,
+                  lastConditions: _lastConditions,
+                  onSimulate: _handleSimulatedCapture,
+                  onBack: _returnToPreparation,
+                )
+              : _PreparationChecklist(
+                  key: const ValueKey<String>('prep'),
+                  checklistItems: _checklistItems,
+                  selections: _checklistSelections,
+                  allComplete: _allChecklistComplete,
+                  onToggle: _toggleChecklistItem,
+                  onBegin: _beginCapture,
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PreparationChecklist extends StatelessWidget {
+  const _PreparationChecklist({
+    super.key,
+    required this.checklistItems,
+    required this.selections,
+    required this.allComplete,
+    required this.onToggle,
+    required this.onBegin,
+  });
+
+  final List<String> checklistItems;
+  final List<bool> selections;
+  final bool allComplete;
+  final void Function(int index, bool? value) onToggle;
+  final VoidCallback onBegin;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('Preparation checklist', style: theme.textTheme.headlineSmall),
+        const SizedBox(height: 12),
+        Text(
+          'Complete these quick steps before capturing your top, side, and back views.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 12),
+        Expanded(
+          child: ListView(
+            children: <Widget>[
+              for (int index = 0; index < checklistItems.length; index++)
+                CheckboxListTile(
+                  value: selections[index],
+                  onChanged: (bool? value) => onToggle(index, value),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  contentPadding: EdgeInsets.zero,
+                  title: Text(checklistItems[index]),
+                ),
+              const SizedBox(height: 12),
+              Text('Sample framing', style: theme.textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Row(
+                children: const <Widget>[
+                  _SampleFrame(label: 'Top view'),
+                  SizedBox(width: 12),
+                  _SampleFrame(label: 'Side view'),
+                  SizedBox(width: 12),
+                  _SampleFrame(label: 'Back view'),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: allComplete ? onBegin : null,
+            child: const Text('Begin'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SampleFrame extends StatelessWidget {
+  const _SampleFrame({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Expanded(
+      child: AspectRatio(
+        aspectRatio: 3 / 4,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(color: theme.colorScheme.primary.withOpacity(0.4), width: 2),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Center(
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CaptureSimulation extends StatelessWidget {
+  const _CaptureSimulation({
+    super.key,
+    required this.isProcessing,
+    required this.statusMessage,
+    required this.lastConditions,
+    required this.onSimulate,
+    required this.onBack,
+  });
+
+  final bool isProcessing;
+  final String? statusMessage;
+  final List<String>? lastConditions;
+  final Future<void> Function() onSimulate;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: isProcessing ? null : onBack,
+              tooltip: 'Back to checklist',
+            ),
+            Text('Guided capture (simulated)', style: theme.textTheme.headlineSmall),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'We\'ll walk through each angle and process everything locally. Use this simulation until the full capture flow is ready.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 20),
+        ElevatedButton.icon(
+          onPressed: isProcessing ? null : onSimulate,
+          icon: const Icon(Icons.qr_code_scanner),
+          label: Text(isProcessing ? 'Processing…' : 'Simulate capture set'),
+        ),
+        const SizedBox(height: 16),
+        if (statusMessage != null)
+          Text(
+            statusMessage!,
+            style: theme.textTheme.bodyMedium?.copyWith(color: Colors.teal.shade700),
+          ),
+        if (lastConditions != null && lastConditions!.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: lastConditions!
+                  .map(
+                    (String condition) => Text(
+                      '• $condition',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/screens/sign_in_screen.dart
+++ b/lib/screens/sign_in_screen.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+
+import '../services/account_service.dart';
+import '../services/app_dependencies.dart';
+
+class SignInScreen extends StatefulWidget {
+  const SignInScreen({
+    super.key,
+    required this.onAccountLinked,
+    required this.onSkip,
+  });
+
+  final Future<void> Function(String accountId) onAccountLinked;
+  final Future<void> Function() onSkip;
+
+  @override
+  State<SignInScreen> createState() => _SignInScreenState();
+}
+
+class _SignInScreenState extends State<SignInScreen>
+    with SingleTickerProviderStateMixin {
+  final GlobalKey<FormState> _signInFormKey = GlobalKey<FormState>();
+  final GlobalKey<FormState> _createFormKey = GlobalKey<FormState>();
+  final TextEditingController _signInContactController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _createContactController = TextEditingController();
+  final TextEditingController _otpController = TextEditingController();
+
+  bool _isSubmitting = false;
+  String? _errorMessage;
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _signInContactController.dispose();
+    _passwordController.dispose();
+    _createContactController.dispose();
+    _otpController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSubmit() async {
+    final AccountService accountService =
+        AppDependencies.of(context).accountService;
+    setState(() {
+      _errorMessage = null;
+    });
+
+    if (_tabController.index == 0) {
+      if (!(_signInFormKey.currentState?.validate() ?? false)) {
+        return;
+      }
+      setState(() {
+        _isSubmitting = true;
+      });
+      try {
+        final AccountResult result = await accountService.signIn(
+          emailOrPhone: _signInContactController.text,
+          password: _passwordController.text,
+        );
+        await widget.onAccountLinked(result.accountId);
+      } on AccountException catch (error) {
+        if (!mounted) return;
+        setState(() {
+          _errorMessage = error.message;
+        });
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isSubmitting = false;
+          });
+        }
+      }
+    } else {
+      if (!(_createFormKey.currentState?.validate() ?? false)) {
+        return;
+      }
+      setState(() {
+        _isSubmitting = true;
+      });
+      try {
+        final AccountResult result = await accountService.createAccount(
+          emailOrPhone: _createContactController.text,
+          otp: _otpController.text,
+        );
+        await widget.onAccountLinked(result.accountId);
+      } on AccountException catch (error) {
+        if (!mounted) return;
+        setState(() {
+          _errorMessage = error.message;
+        });
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isSubmitting = false;
+          });
+        }
+      }
+    }
+  }
+
+  String? _validateContact(String? value) {
+    final String trimmed = value?.trim() ?? '';
+    if (trimmed.isEmpty) {
+      return 'Please enter your email or phone number.';
+    }
+    final bool looksLikeEmail = trimmed.contains('@');
+    final bool looksLikePhone =
+        trimmed.replaceAll(RegExp(r'[^0-9]'), '').length >= 10;
+    if (!looksLikeEmail && !looksLikePhone) {
+      return 'Enter a valid email or phone number.';
+    }
+    return null;
+  }
+
+  String? _validatePassword(String? value) {
+    if (value == null || value.trim().length < 6) {
+      return 'Password must be at least 6 characters.';
+    }
+    return null;
+  }
+
+  String? _validateOtp(String? value) {
+    if (value == null || value.trim().length != 6) {
+      return 'Enter the 6-digit code sent to you.';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sync your scans'),
+        automaticallyImplyLeading: false,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Create an account to sync your history across devices. You can also keep everything on this phone.',
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 16),
+              TabBar(
+                controller: _tabController,
+                labelColor: theme.colorScheme.primary,
+                unselectedLabelColor: theme.textTheme.bodyMedium?.color,
+                indicatorColor: theme.colorScheme.primary,
+                tabs: const <Tab>[
+                  Tab(text: 'Sign in'),
+                  Tab(text: 'Create account'),
+                ],
+              ),
+              Expanded(
+                child: TabBarView(
+                  controller: _tabController,
+                  children: <Widget>[
+                    Form(
+                      key: _signInFormKey,
+                      child: ListView(
+                        padding: const EdgeInsets.only(top: 24),
+                        children: <Widget>[
+                          TextFormField(
+                            controller: _signInContactController,
+                            keyboardType: TextInputType.emailAddress,
+                            textInputAction: TextInputAction.next,
+                            decoration: const InputDecoration(
+                              labelText: 'Email or phone',
+                            ),
+                            validator: _validateContact,
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _passwordController,
+                            obscureText: true,
+                            decoration: const InputDecoration(
+                              labelText: 'Password',
+                            ),
+                            validator: _validatePassword,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Form(
+                      key: _createFormKey,
+                      child: ListView(
+                        padding: const EdgeInsets.only(top: 24),
+                        children: <Widget>[
+                          TextFormField(
+                            controller: _createContactController,
+                            keyboardType: TextInputType.emailAddress,
+                            textInputAction: TextInputAction.next,
+                            decoration: const InputDecoration(
+                              labelText: 'Email or phone',
+                            ),
+                            validator: _validateContact,
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _otpController,
+                            keyboardType: TextInputType.number,
+                            decoration: const InputDecoration(
+                              labelText: 'One-time code',
+                              hintText: '6-digit code',
+                            ),
+                            validator: _validateOtp,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'We send a quick code to verify your device. Enter the 6 digits to finish setting up your account.',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (_errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(
+                    _errorMessage!,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                  ),
+                ),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _isSubmitting ? null : _handleSubmit,
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Continue'),
+                ),
+              ),
+              TextButton(
+                onPressed: _isSubmitting
+                    ? null
+                    : () async {
+                        await widget.onSkip();
+                      },
+                child: const Text('Continue without account'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/account_service.dart
+++ b/lib/services/account_service.dart
@@ -1,0 +1,64 @@
+class AccountResult {
+  const AccountResult({required this.accountId});
+
+  final String accountId;
+}
+
+enum AccountError { invalidCredentials, offline }
+
+class AccountException implements Exception {
+  AccountException(this.error, this.message);
+
+  final AccountError error;
+  final String message;
+
+  @override
+  String toString() => 'AccountException($error, $message)';
+}
+
+class AccountService {
+  bool _connectionAvailable = true;
+
+  void setConnectionAvailable(bool value) {
+    _connectionAvailable = value;
+  }
+
+  Future<AccountResult> signIn({
+    required String emailOrPhone,
+    required String password,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    _ensureConnection();
+    if (password.trim().length < 6) {
+      throw AccountException(
+        AccountError.invalidCredentials,
+        'Invalid password. Please try again.',
+      );
+    }
+    return AccountResult(accountId: emailOrPhone.trim());
+  }
+
+  Future<AccountResult> createAccount({
+    required String emailOrPhone,
+    required String otp,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 350));
+    _ensureConnection();
+    if (otp.trim().length != 6) {
+      throw AccountException(
+        AccountError.invalidCredentials,
+        'Invalid code. Please check the digits and try again.',
+      );
+    }
+    return AccountResult(accountId: emailOrPhone.trim());
+  }
+
+  void _ensureConnection() {
+    if (!_connectionAvailable) {
+      throw AccountException(
+        AccountError.offline,
+        'Check your connection and try again.',
+      );
+    }
+  }
+}

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+
+class AnalyticsEvent {
+  const AnalyticsEvent(this.name, [this.parameters = const <String, dynamic>{}]);
+
+  final String name;
+  final Map<String, dynamic> parameters;
+}
+
+class AnalyticsService extends ChangeNotifier {
+  final List<AnalyticsEvent> _events = <AnalyticsEvent>[];
+
+  List<AnalyticsEvent> get events => List<AnalyticsEvent>.unmodifiable(_events);
+
+  void recordEvent(String name, [Map<String, dynamic>? parameters]) {
+    _events.add(AnalyticsEvent(name, parameters ?? const <String, dynamic>{}));
+    notifyListeners();
+  }
+
+  void reset() {
+    _events.clear();
+    notifyListeners();
+  }
+}

--- a/lib/services/app_dependencies.dart
+++ b/lib/services/app_dependencies.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/widgets.dart';
+
+import 'account_service.dart';
+import 'analytics_service.dart';
+import 'legal_content_service.dart';
+import 'offline_data_store.dart';
+import 'permission_service.dart';
+import 'processing_service.dart';
+
+class AppDependencies extends InheritedWidget {
+  const AppDependencies({
+    super.key,
+    required super.child,
+    required this.offlineDataStore,
+    required this.permissionService,
+    required this.processingService,
+    required this.accountService,
+    required this.analyticsService,
+    required this.legalContentService,
+  });
+
+  final OfflineDataStore offlineDataStore;
+  final PermissionService permissionService;
+  final ProcessingService processingService;
+  final AccountService accountService;
+  final AnalyticsService analyticsService;
+  final LegalContentService legalContentService;
+
+  static AppDependencies of(BuildContext context) {
+    final AppDependencies? dependencies =
+        context.dependOnInheritedWidgetOfExactType<AppDependencies>();
+    assert(
+      dependencies != null,
+      'AppDependencies.of() called with a context that does not contain AppDependencies.',
+    );
+    return dependencies!;
+  }
+
+  @override
+  bool updateShouldNotify(AppDependencies oldWidget) {
+    return offlineDataStore != oldWidget.offlineDataStore ||
+        permissionService != oldWidget.permissionService ||
+        processingService != oldWidget.processingService ||
+        accountService != oldWidget.accountService ||
+        analyticsService != oldWidget.analyticsService ||
+        legalContentService != oldWidget.legalContentService;
+  }
+}

--- a/lib/services/legal_content_service.dart
+++ b/lib/services/legal_content_service.dart
@@ -1,0 +1,23 @@
+enum LegalDocumentType { terms, privacy }
+
+class LegalContentService {
+  bool _simulateFailure = false;
+
+  void setSimulateFailure(bool value) {
+    _simulateFailure = value;
+  }
+
+  Future<String> fetchDocument(LegalDocumentType type) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    if (_simulateFailure) {
+      throw Exception('Unable to load document.');
+    }
+
+    switch (type) {
+      case LegalDocumentType.terms:
+        return 'HairGuard Terms of Use\n\nUse HairGuard responsibly. By continuing, you agree to local storage and on-device analysis.';
+      case LegalDocumentType.privacy:
+        return 'HairGuard Privacy Policy\n\nYour scans stay on this device unless you choose to share them.';
+    }
+  }
+}

--- a/lib/services/offline_data_store.dart
+++ b/lib/services/offline_data_store.dart
@@ -1,0 +1,83 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+class ScanSession {
+  ScanSession({
+    required this.id,
+    required this.createdAt,
+    this.summary,
+  });
+
+  final String id;
+  final DateTime createdAt;
+  final String? summary;
+}
+
+enum AccountPreference { unknown, signedIn, skipped }
+
+class OfflineDataStore extends ChangeNotifier {
+  bool _initialized = false;
+  final List<ScanSession> _sessions = <ScanSession>[];
+  bool _onboardingComplete = false;
+  AccountPreference _accountPreference = AccountPreference.unknown;
+  String? _linkedAccountId;
+
+  bool get isInitialized => _initialized;
+
+  bool get hasCompletedOnboarding => _onboardingComplete;
+
+  bool get hasLinkedAccount => _accountPreference == AccountPreference.signedIn;
+
+  bool get shouldPromptForAccount =>
+      _accountPreference == AccountPreference.unknown;
+
+  String? get linkedAccountId => _linkedAccountId;
+
+  UnmodifiableListView<ScanSession> get sessions =>
+      UnmodifiableListView<ScanSession>(_sessions);
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+    _initialized = true;
+    notifyListeners();
+  }
+
+  Future<void> saveSession(ScanSession session) async {
+    await initialize();
+    _sessions.insert(0, session);
+    notifyListeners();
+  }
+
+  Future<void> clearSessions() async {
+    await initialize();
+    _sessions.clear();
+    notifyListeners();
+  }
+
+  Future<void> setOnboardingComplete() async {
+    await initialize();
+    if (_onboardingComplete) {
+      return;
+    }
+    _onboardingComplete = true;
+    notifyListeners();
+  }
+
+  Future<void> linkAccount(String accountId) async {
+    await initialize();
+    _linkedAccountId = accountId;
+    _accountPreference = AccountPreference.signedIn;
+    notifyListeners();
+  }
+
+  Future<void> skipAccount() async {
+    await initialize();
+    _linkedAccountId = null;
+    _accountPreference = AccountPreference.skipped;
+    notifyListeners();
+  }
+}

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -1,0 +1,19 @@
+enum PermissionStatus { granted, denied, restricted }
+
+class PermissionService {
+  PermissionStatus _cameraStatus = PermissionStatus.denied;
+
+  PermissionStatus get cameraStatus => _cameraStatus;
+
+  Future<PermissionStatus> ensureCameraPermission() async {
+    if (_cameraStatus == PermissionStatus.granted) {
+      return _cameraStatus;
+    }
+
+    // Placeholder stub: in a real implementation this would request the
+    // platform permission. We simulate a granted response after a short delay.
+    await Future<void>.delayed(const Duration(milliseconds: 120));
+    _cameraStatus = PermissionStatus.granted;
+    return _cameraStatus;
+  }
+}

--- a/lib/services/processing_service.dart
+++ b/lib/services/processing_service.dart
@@ -1,0 +1,29 @@
+class ProcessingResult {
+  ProcessingResult({
+    required this.summary,
+    required this.conditions,
+    required this.modelVersion,
+  });
+
+  final String summary;
+  final List<String> conditions;
+  final String modelVersion;
+}
+
+class ProcessingService {
+  String get modelVersion => 'v0.1-local';
+
+  Future<ProcessingResult> processCaptureSet(List<String> imagePaths) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+
+    return ProcessingResult(
+      summary: imagePaths.isEmpty
+          ? 'No captures yet — start a new scan to see insights.'
+          : 'Preliminary results ready to review.',
+      conditions: imagePaths.isEmpty
+          ? const <String>[]
+          : const <String>['Dandruff — Moderate', 'Irritation — Mild'],
+      modelVersion: modelVersion,
+    );
+  }
+}

--- a/lib/widgets/legal_document_sheet.dart
+++ b/lib/widgets/legal_document_sheet.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class LegalDocumentSheet extends StatefulWidget {
+  const LegalDocumentSheet({
+    super.key,
+    required this.title,
+    required this.loader,
+  });
+
+  final String title;
+  final Future<String> Function() loader;
+
+  @override
+  State<LegalDocumentSheet> createState() => _LegalDocumentSheetState();
+}
+
+class _LegalDocumentSheetState extends State<LegalDocumentSheet> {
+  late Future<String> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.loader();
+  }
+
+  void _retry() {
+    setState(() {
+      _future = widget.loader();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    widget.title,
+                    style: theme.textTheme.titleLarge,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close),
+                  onPressed: () => Navigator.of(context).maybePop(),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            FutureBuilder<String>(
+              future: _future,
+              builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 32),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                if (snapshot.hasError) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        'We couldn\'t load this right now.',
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      TextButton(
+                        onPressed: _retry,
+                        child: const Text('Try again'),
+                      ),
+                    ],
+                  );
+                }
+                return SingleChildScrollView(
+                  child: Text(
+                    snapshot.data ?? '',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,43 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:skalp_guard/main.dart';
+import 'package:skalp_guard/navigation/app_navigation.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Onboarding requires consent before entering the app shell',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const HairGuardApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Welcome to HairGuard'), findsOneWidget);
+
+    final Finder consentCheckbox = find.byType(CheckboxListTile);
+    expect(consentCheckbox, findsOneWidget);
+
+    ElevatedButton continueButton =
+        tester.widget(find.widgetWithText(ElevatedButton, 'Continue'));
+    expect(continueButton.onPressed, isNull);
+
+    await tester.tap(consentCheckbox);
+    await tester.pumpAndSettle();
+
+    continueButton =
+        tester.widget(find.widgetWithText(ElevatedButton, 'Continue'));
+    expect(continueButton.onPressed, isNotNull);
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sync your scans'), findsOneWidget);
+
+    await tester.tap(find.text('Continue without account'));
+    await tester.pumpAndSettle();
+
+    final BottomNavigationBar bottomNav =
+        tester.widget(find.byType(BottomNavigationBar));
+
+    expect(bottomNav.items, hasLength(AppTab.values.length));
   });
 }


### PR DESCRIPTION
## Summary
- implement the onboarding carousel with consent gating, terms/privacy loaders, and transition into the next step only after agreement
- add the optional sign-in/create-account flow plus analytics, account, and legal content services while refreshing the home empty state with tips and privacy links
- gate the scan experience with a preparation checklist and sample frames before entering the existing simulated capture stub

## Testing
- `flutter test` *(fails: Flutter SDK is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de577bfd348326958e04a09c58e236